### PR TITLE
allow multiple search paths, displaying solutions in sorted order

### DIFF
--- a/commands/list.js
+++ b/commands/list.js
@@ -4,7 +4,7 @@ const open = require("open");
 const leftPad = require("left-pad");
 const minimist = require("minimist");
 const path = require("path");
-var unique = require('array-unique');
+const unique = require('array-unique');
 
 const sourceDir = process.cwd();
 

--- a/commands/list.js
+++ b/commands/list.js
@@ -4,15 +4,24 @@ const open = require("open");
 const leftPad = require("left-pad");
 const minimist = require("minimist");
 const path = require("path");
+var unique = require('array-unique');
 
 const sourceDir = process.cwd();
 
 module.exports = {
     execute: function(commandName, commandArgs) {
-        dir.promiseFiles(sourceDir)
-        .then(files => {
-            return files.filter(fileName => fileName.match(/\.sln$/));
-        })
+        let paths = commandArgs["_"];
+
+        if( !paths || paths.length==0 ) {
+            paths = [sourceDir];
+        }
+
+        Promise.all(paths.map(p => dir.promiseFiles(p)))
+        .then(fileLists => [].concat.apply([], fileLists))
+        .then(files => files.filter(fileName => fileName.match(/\.sln$/)))
+        .then(files => files.map(file => path.resolve(file)))
+        .then(files => unique(files))
+        .then(files => files.sort())
         .then(solutionFiles => {
             if (commandArgs.filter) {
                 return solutionFiles.filter(filePath => {
@@ -41,7 +50,7 @@ module.exports = {
         })
         .then(solutionFiles => {
             for(let i = 0; i < solutionFiles.length; i++) {
-                const option = solutionFiles[i].slice(sourceDir.length+1);
+                const option = path.relative(process.cwd(), solutionFiles[i]).replace(/^..(\/|\\)/, '');
                 console.log(`${leftPad(i+1, 5)}: ${option}`);
             }
         })

--- a/commands/open.js
+++ b/commands/open.js
@@ -4,15 +4,24 @@ const open = require("open");
 const leftPad = require("left-pad");
 const minimist = require("minimist");
 const path = require("path");
+const unique = require('array-unique');
 
 const sourceDir = process.cwd();
 
 module.exports = {
     execute: function(commandName, commandArgs) {
-        dir.promiseFiles(sourceDir)
-        .then(files => {
-            return files.filter(fileName => fileName.match(/\.sln$/));
-        })
+        let paths = commandArgs["_"];
+
+        if (!paths || paths.length == 0) {
+            paths = [sourceDir];
+        }
+
+        Promise.all(paths.map(p => dir.promiseFiles(p)))
+        .then(fileLists => [].concat.apply([], fileLists))
+        .then(files => files.filter(fileName => fileName.match(/\.sln$/)))
+        .then(files => files.map(file => path.resolve(file)))
+        .then(files => unique(files))
+        .then(files => files.sort())
         .then(solutionFiles => {
             if (commandArgs.filter) {
                 return solutionFiles.filter(filePath => {
@@ -45,8 +54,8 @@ module.exports = {
             console.log("");
 
             for(let i = 0; i < solutionFiles.length; i++) {
-                const option = solutionFiles[i].slice(sourceDir.length+1);
-                console.log(`${leftPad(i+1, 5)}: ${option}`);
+                const option = path.relative(process.cwd(), solutionFiles[i]).replace(/^..(\/|\\)/, '');
+                console.log(`${leftPad(i + 1, 5)}: ${option}`);
             }
 
             return new Promise((resolve, reject) => {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/jensandresen/node-osln#readme",
   "dependencies": {
+    "array-unique": "^0.3.2",
     "left-pad": "^1.1.3",
     "node-dir": "^0.1.17",
     "open": "0.0.5",


### PR DESCRIPTION
- search multiple paths from arguments, with a fallback to current
directory if nothing is specified.
- solutions are now in (linux) sorted order