### PR TITLE
skip solultions for excluded paths

### DIFF
--- a/commands/list.js
+++ b/commands/list.js
@@ -5,6 +5,7 @@ const leftPad = require("left-pad");
 const minimist = require("minimist");
 const path = require("path");
 const unique = require('array-unique');
+const settings = require("../utils/settings");
 
 const sourceDir = process.cwd();
 
@@ -19,6 +20,7 @@ module.exports = {
         Promise.all(paths.map(p => dir.promiseFiles(p)))
         .then(fileLists => [].concat.apply([], fileLists))
         .then(files => files.filter(fileName => fileName.match(/\.sln$/)))
+        .then(files => files.filter(file => settings.getExcludedPath().every(exclude => !path.dirname(file).match(exclude))))
         .then(files => files.map(file => path.resolve(file)))
         .then(files => unique(files))
         .then(files => files.sort())

--- a/commands/open.js
+++ b/commands/open.js
@@ -5,6 +5,7 @@ const leftPad = require("left-pad");
 const minimist = require("minimist");
 const path = require("path");
 const unique = require('array-unique');
+const settings = require("../utils/settings");
 
 const sourceDir = process.cwd();
 
@@ -19,6 +20,7 @@ module.exports = {
         Promise.all(paths.map(p => dir.promiseFiles(p)))
         .then(fileLists => [].concat.apply([], fileLists))
         .then(files => files.filter(fileName => fileName.match(/\.sln$/)))
+        .then(files => files.filter(file => settings.getExcludedPath().every(exclude => !path.dirname(file).match(exclude))))
         .then(files => files.map(file => path.resolve(file)))
         .then(files => unique(files))
         .then(files => files.sort())

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,6 +2,7 @@
   "name": "osln",
   "version": "1.3.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "array-unique": {
       "version": "0.3.2",
@@ -16,12 +17,21 @@
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI="
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "is-wsl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
     },
     "left-pad": {
       "version": "1.1.3",
@@ -31,7 +41,10 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
     },
     "minimist": {
       "version": "1.2.0",
@@ -41,12 +54,18 @@
     "node-dir": {
       "version": "0.1.17",
       "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
-      "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU="
+      "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
+      "requires": {
+        "minimatch": "^3.0.2"
+      }
     },
     "open": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/open/-/open-0.0.5.tgz",
-      "integrity": "sha1-QsPhjslUZra/DcQvOilFw/DK2Pw="
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-6.3.0.tgz",
+      "integrity": "sha512-6AHdrJxPvAXIowO/aIaeHZ8CeMdDf7qCyRNq8NwJpinmCdXhz+NZR7ie1Too94lpciCDsG+qHGO9Mt0svA4OqA==",
+      "requires": {
+        "is-wsl": "^1.1.0"
+      }
     },
     "right-pad": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,9 @@
     "array-unique": "^0.3.2",
     "left-pad": "^1.1.3",
     "node-dir": "^0.1.17",
-    "open": "0.0.5",
+    "open": "^6.3.0",
     "right-pad": "^1.0.1",
     "minimist": "^1.2.0"
+
   }
 }

--- a/utils/settings.js
+++ b/utils/settings.js
@@ -8,6 +8,10 @@ module.exports = {
     getVersion: function() {
         const info = require("./../package.json");
         return info.version;
+    },
+
+    getExcludedPath: function() {
+        return [/node_modules/];
     }
 
 };


### PR DESCRIPTION
* 1st commit: bumped the `open` package version due to vulnerabilities
* 2nd commit: added the excluded path feature (currently it only ignores `node_modules` in the path)